### PR TITLE
FIX compatibility php8

### DIFF
--- a/core/modules/modeasya.class.php
+++ b/core/modules/modeasya.class.php
@@ -390,6 +390,8 @@ class modeasya extends DolibarrModules
 	 */
 	public function remove($options = '')
 	{
+		$sql = array();
+
 		dolibarr_del_const($this->db,'EASYA_VERSION');
 		dolibarr_del_const($this->db,'MAIN_FONTAWESOME_DIRECTORY');
 		dolibarr_del_const($this->db,'MAIN_FONTAWESOME_FAMILY');

--- a/core/modules/modeasya.class.php
+++ b/core/modules/modeasya.class.php
@@ -390,7 +390,6 @@ class modeasya extends DolibarrModules
 	 */
 	public function remove($options = '')
 	{
-		$sql = array();
 
 		dolibarr_del_const($this->db,'EASYA_VERSION');
 		dolibarr_del_const($this->db,'MAIN_FONTAWESOME_DIRECTORY');
@@ -400,6 +399,9 @@ class modeasya extends DolibarrModules
 		dolibarr_del_const($this->db,'INFRASPACKPLUS_DISABLED_CORE_CHANGE');
 		dolibarr_del_const($this->db,'INFRASPACKPLUS_DISABLED_MODULE_CHANGE');
 		dolibarr_del_const($this->db,'MAIN_MODULE_SETUP_ON_LIST_BY_DEFAULT');
+
+		//set $sql to array() to avoid an error with count() in php8 inside $this->_remove()
+		$sql = array();
 
 		return $this->_remove($sql, $options);
 	}


### PR DESCRIPTION
FIX compatibility php8.0 function remove, $sql set to array() to not have an error when removing the module (function count() received a null since $sql was not set and since php8.0 count launch an error if the type is not countable)